### PR TITLE
Threads and batch arguments, reading fastq by lines.

### DIFF
--- a/sickle.xml
+++ b/sickle.xml
@@ -102,6 +102,14 @@
 			<validator type="in_range" min="0" message="Minimum value is 0"/>
 		</param>
 
+		<param name="threads" value="1" type="integer" optional="true" label="Number of Threads">
+			<validator type="in_range" min="1" message="Minimum value is 1"/>
+		</param>
+
+		<param name="batch" value="1000" type="integer" optional="true" label="Length, in megabytes, of the input batch.">
+			<validator type="in_range" min="1" message="Minimum value is 1"/>
+		</param>
+
 		<param name="no_five_prime" type="boolean" label="Don't do 5' trimming"/>
 		<param name="trunc_n" type="boolean" label="Truncate sequences with Ns at first N position"/>
 	</inputs>

--- a/src/Batch.cpp
+++ b/src/Batch.cpp
@@ -3,22 +3,57 @@
 
 using namespace std;
 
-Batch::Batch(const char * buffer){
-    msg("Making buffer");
-    auto [view1, view2] = view_and_remainder(buffer);
-    this->content = view1;
-    this->remaining = view2;
-    sequences_len = 0;
-    msg("Make lines?");
-    if(content.length()>0){
-        make_lines();
-        //splitSVPtr("\n");
-    }else{
-        msg("No, empty content");
-    }
+Batch::Batch(vector<const char*>* lines_raw){
+    //msg("Making buffer");
+    this->lines_raw = lines_raw;
     last_line = -1;
-    msg(string("Made buffer with ") + to_string(lines.size()) + string(" lines"));
+    sequences_len = 0;
+    //int lines_with_n = 0;
+    for(int i = 0; i < lines_raw->size(); i++){
+        const char* line_raw = lines_raw->at(i);
+        lines.push_back(string_view{line_raw});
+        sequences_len += lines.back().length();
+        //if(lines.back().back() == '\n') lines_with_n++;
+    }
+    //msg(string("Lines with \\n at the end: ") + to_string(lines_with_n));
+    //msg(string("Made buffer with ") + to_string(lines.size()) + string(" lines"));
     assert(lines.size() % 4 == 0);
+}
+
+Batch::Batch(vector<const char*>* lines_raw, vector<const char*>* previous_lines){
+    //msg("Making buffer");
+    this->lines_raw = lines_raw;
+    //msg("linew_raw");
+    //msg(to_string(lines_raw->size()));
+    //msg(to_string(lines_raw->size()%4));
+    this->previous_lines = previous_lines;
+    //msg("previous_lines");
+    //msg(to_string(previous_lines->size()));
+    last_line = -1;
+    sequences_len = 0;
+    //int lines_with_n = 0;
+    for(int i = 0; i < previous_lines->size(); i++){
+        const char* line_raw = previous_lines->at(i);
+        lines.push_back(string_view{line_raw});
+        sequences_len += lines.back().length();
+        //if(lines.back().back() == '\n') lines_with_n++;
+    }
+    for(int i = 0; i < lines_raw->size(); i++){
+        const char* line_raw = lines_raw->at(i);
+        lines.push_back(string_view{line_raw});
+        sequences_len += lines.back().length();
+        //if(lines.back().back() == '\n') lines_with_n++;
+    }
+    //msg(string("Lines with \\n at the end: ") + to_string(lines_with_n));
+    //msg(string("Made buffer with ") + to_string(lines.size()) + string(" lines"));
+    assert(lines.size() % 4 == 0);
+}
+
+void Batch::free_this(){
+    for(int i = 0; i < lines_raw->size(); i++){
+		delete(lines_raw->at(i));
+	}
+	delete(lines_raw);
 }
 
 int Batch::n_lines(){
@@ -33,6 +68,31 @@ string_view Batch::next_line(){
     assert(has_lines());
     last_line += 1;
     return lines.at(last_line);
+}
+
+/*
+Batch::Batch(const char * buffer, bool eof){
+    msg("Making buffer");
+    if(!eof){
+        auto [view1, view2] = view_and_remainder(buffer);
+        this->content = view1;
+        this->remaining = view2;
+    }else{
+        content = string_view{buffer, strlen(buffer)};
+        remaining = string_view{"", 0};
+    }
+    
+    sequences_len = 0;
+    msg("Make lines?");
+    if(content.length()>0){
+        make_lines();
+        //splitSVPtr("\n");
+    }else{
+        msg("No, empty content");
+    }
+    last_line = -1;
+    msg(string("Made buffer with ") + to_string(lines.size()) + string(" lines"));
+    assert(lines.size() % 4 == 0);
 }
 
 const char * Batch::get_remainder(){
@@ -161,4 +221,4 @@ tuple<string_view, string_view> Batch::view_and_remainder(const char * chars,
 tuple<string_view, string_view> Batch::view_and_remainder(const char * chars)
 {
     return view_and_remainder(chars, strlen(chars));
-}
+}*/

--- a/src/Batch.h
+++ b/src/Batch.h
@@ -16,8 +16,9 @@ using namespace std;
 
 class Batch{
 public:
-    Batch(const char * buffer);
-
+    //Batch(const char * buffer, bool eof = false);
+    Batch(vector<const char*>* lines);
+    Batch(vector<const char*>* lines, vector<const char*>* previous_lines);
     bool has_lines();
 
     string_view next_line();
@@ -26,23 +27,26 @@ public:
 
     int sequences_len;
     int n_lines();
+    void free_this();
 private:
-    void splitSVPtr(std::string_view delims = " ");
-    string_view content, remaining;
+    //void splitSVPtr(std::string_view delims = " ");
+    //string_view content, remaining;
     vector<string_view> lines;
     size_t last_line;
+    vector<const char*>* lines_raw;
+    vector<const char*>* previous_lines;
 
-    void make_lines();
+    //void make_lines();
 
-    int get_next_newline(size_t from);
+    //int get_next_newline(size_t from);
 
-    tuple<string_view, string_view> view_and_remainder(const char * chars,
-        unsigned last_newline, unsigned total_len);
+    //tuple<string_view, string_view> view_and_remainder(const char * chars,
+    //    unsigned last_newline, unsigned total_len);
 
-    tuple<string_view, string_view> view_and_remainder(const char * chars,
-        unsigned total_len);
+    //tuple<string_view, string_view> view_and_remainder(const char * chars,
+    //    unsigned total_len);
 
-    tuple<string_view, string_view> view_and_remainder(const char * chars);
+    //tuple<string_view, string_view> view_and_remainder(const char * chars);
 };
 
 #endif

--- a/src/GZReader.h
+++ b/src/GZReader.h
@@ -13,22 +13,24 @@ using namespace std;
 
 class GZReader{
 public:
-    GZReader(char* path, int batch_len);
+    GZReader(char* path, int batch_len, bool interleaved = false);
     ~GZReader();
     //std::string_view readline();
     //std::string_view* read4();
-    Batch* get_batch();
-    Batch* get_batch(string remains);
+    Batch* get_batch_buffering_lines();
+    vector<const char*>* read_lines();
+    bool reached_end();
 
-    
     //int buffer_len();
     char* path;
 private:
     tuple<const char*, int> read_n_chars(int n_chars);
-    bool reached_end();
+    vector<const char*>* last_remainder = NULL;
     gzFile file;
     bool eof;
     int batch_len;
+    char* last_lines_buffer = NULL;
+    int min_lines_in_batch;
     //int more_buffer();
     //int find_newline_in_buffer();
     //void make_lines_from_buffer();

--- a/src/sickle.h
+++ b/src/sickle.h
@@ -24,7 +24,7 @@
 #endif
 
 #ifndef DEFAULT_BATCH_LEN
-#define DEFAULT_BATCH_LEN 1024*1024*512
+#define DEFAULT_BATCH_LEN 1000
 #endif
 
 /* Options drawn from GNU's coreutils/src/system.h */

--- a/src/trim_single.h
+++ b/src/trim_single.h
@@ -14,7 +14,7 @@ public:
         cutsites** saved_cutsites, long last_index, int thread_n);
     void usage(int status, char const *msg);
     void output_single(std::vector<std::vector<FQEntry*>* > queues, bool** filtered_reads, 
-        cutsites*** saved_cutsites, vector<long> last_index);
+        cutsites*** saved_cutsites, vector<long> last_index, Batch* batch);
     int init_streams();
     void close_streams();
 };


### PR DESCRIPTION
Added arguments to define the number of threads and batch length:
        -a Number of Threads. Minimum and default: 1;
	-b Length in megabytes of the batch of fastq lines that will be read and processed. Minimum: 1. Default: 1000.
		sickle won't read exactly this number of chars because the number of lines in the batch must be a multiple of 4 (or 8, if it is an interleaved paired end file).

In order to fix several possible file reading problems, GZReader is now reading the files line by line using the gzgets() function.